### PR TITLE
remove Authorize attribute

### DIFF
--- a/src/OpenID/OpenIdProviderMvc/Controllers/HomeController.cs
+++ b/src/OpenID/OpenIdProviderMvc/Controllers/HomeController.cs
@@ -5,7 +5,7 @@
 	using System.Web;
 	using System.Web.Mvc;
 
-	[HandleError, Authorize]
+	[HandleError]
 	public class HomeController : Controller {
 		public ActionResult Index() {
 			if (Request.AcceptTypes.Contains("application/xrds+xml")) {


### PR DESCRIPTION
Having the authorise attribute on the home controller prevents xrds requests from succeeding.
