### PR TITLE
Fix approval denied return so it's valid

### DIFF
--- a/src/OAuth/OAuthAuthorizationServer/Controllers/OAuthController.cs
+++ b/src/OAuth/OAuthAuthorizationServer/Controllers/OAuthController.cs
@@ -84,6 +84,9 @@
 				response = this.authorizationServer.PrepareApproveAuthorizationRequest(pendingRequest, User.Identity.Name);
 			} else {
 				response = this.authorizationServer.PrepareRejectAuthorizationRequest(pendingRequest);
+				var errorResponse = response as EndUserAuthorizationFailedResponse;
+				errorResponse.Error = "accesss_denied";  // see http://tools.ietf.org/id/draft-ietf-oauth-v2-31.html#rfc.section.4.1.2.1 for valid values
+				errorResponse.Description = "The resource owner or authorization server denied the request";
 			}
 
 			return this.authorizationServer.Channel.PrepareResponse(response).AsActionResult();


### PR DESCRIPTION
Sample will fail since PrepareResponse() will error without setting the required error field when the user denies access.
